### PR TITLE
Fix the bad class name used in cron filter

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ use Bluehost\SiteMeta; // From plugin
 use function NewfoldLabs\WP\ModuleLoader\register as registerModule;
 
 /**
- * Register the data module
+ * Register the newfold customer data module for bluehost
  */
 if ( function_exists( 'add_action' ) ) {
 
@@ -18,9 +18,7 @@ if ( function_exists( 'add_action' ) ) {
 				array(
 					'name'     => 'newfold-customer-bluehost',
 					'label'    => __( 'Customer Bluehost', 'newfold-customer-bluehost' ),
-					'callback' => function ( Container $container ) {
-						new CustomerBluehost( $container );
-					},
+					'callback' => 'newfold_module_load_customer_bluehost',
 					'isActive' => true,
 					'isHidden' => true,
 				)
@@ -28,24 +26,37 @@ if ( function_exists( 'add_action' ) ) {
 
 		}
 	);
-    
-	// Add filter callback to add bluehost customer data to data module in cron event data
-	add_filter( 
-        'newfold_wp_data_module_cron_data_filter',
-        function( $data ) {
-            // Filter the cron event data object with bluehost specific customer data
-            $data['customer'] = Customer\Bluehost::collect();
-            return $data;
-        }
-    );
+}
 
-	// Add filter callback to add site_id to core data module data
-	add_filter( 
-        'newfold_wp_data_module_core_data_filter',
-        function( $data ) {
-            $data['site_id'] = SiteMeta::get_id();
-            return $data;
-        }
-    );
+/**
+ * Initialize CustomerBluehost class instance and add required filters
+ * 
+ * @param Container the module loader container
+ * @return void
+ */
+function newfold_module_load_customer_bluehost( Container $container ) {
+    new CustomerBluehost( $container );
+    
+
+    if ( function_exists( 'add_filter' ) ) {
+        // Add filter for adding bluehost customer data to data module in cron event data
+        add_filter( 
+            'newfold_wp_data_module_cron_data_filter',
+            function( $data ) {
+                // Filter the cron event data object with bluehost specific customer data
+                $data['customer'] = CustomerBluehost::collect();
+                return $data;
+            }
+        );
+
+        // Add filter to add site_id to core data module data
+        add_filter( 
+            'newfold_wp_data_module_core_data_filter',
+            function( $data ) {
+                $data['site_id'] = SiteMeta::get_id();
+                return $data;
+            }
+        );
+    }
 
 }


### PR DESCRIPTION
In getting the class names updated I forgot this one.

`Customer\Bluehost() !== CustomerBluehost()`